### PR TITLE
feat: Inclui nome e email do usuário no token JWT

### DIFF
--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -39,7 +39,7 @@ exports.signin = async (req, res) => {
       return res.status(401).send({ message: "Senha inválida!" });
     }
 
-    const token = jwt.sign({ id: user.id }, process.env.JWT_SECRET, {
+    const token = jwt.sign({ id: user.id, name: user.name, email: user.email }, process.env.JWT_SECRET, {
       expiresIn: 86400 // 24 horas
     });
 

--- a/middlewares/authJwt.js
+++ b/middlewares/authJwt.js
@@ -15,6 +15,8 @@ module.exports = (req, res, next) => {
       return res.status(401).send({ message: "Token inválido!" });
     }
     req.userId = decoded.id;
+    req.userName = decoded.name;
+    req.userEmail = decoded.email;
     next();
   });
 };


### PR DESCRIPTION
Modifica a função de login (signin) para incluir os campos 'name' e 'email' do usuário no payload do token JWT, além do 'id' já existente. A expiração do token permanece em 24 horas.

O middleware authJwt.js também foi atualizado para popular o objeto 'req' com 'userName' e 'userEmail' a partir do token decodificado, facilitando o acesso a esses dados em rotas protegidas.